### PR TITLE
Synchronize on instance

### DIFF
--- a/src/main/java/org/elasticsearch/ingest/openshift/OpenshiftIndexProcessor.java
+++ b/src/main/java/org/elasticsearch/ingest/openshift/OpenshiftIndexProcessor.java
@@ -69,7 +69,7 @@ public final class OpenshiftIndexProcessor extends AbstractProcessor {
 
         ClusterState eventState = event.state();
 
-        synchronized (OpenshiftIndexProcessor.class) {
+        synchronized (this) {
             if (eventState.version() > clusterStateVersion) {
                 latestAliasAndIndicesLookup = eventState.metaData().getAliasAndIndexLookup();
                 clusterStateVersion = eventState.version();

--- a/src/main/java/org/elasticsearch/ingest/openshift/OpenshiftIngestPlugin.java
+++ b/src/main/java/org/elasticsearch/ingest/openshift/OpenshiftIngestPlugin.java
@@ -99,7 +99,7 @@ public class OpenshiftIngestPlugin extends Plugin implements IngestPlugin, Clust
 
             ClusterState eventState = event.state();
 
-            synchronized (OpenshiftIngestPlugin.class) {
+            synchronized (this) {
                 if (eventState.version() > clusterStateVersion) {
                     latestAliasAndIndicesLookup = eventState.metaData().getAliasAndIndexLookup();
                     clusterStateVersion = eventState.version();


### PR DESCRIPTION
Given that metadata version and aliases-&-indices lookup table
is kept at the instance level we should synchronize via "this"
monitor and not on class object.