### PR TITLE
Skip check of initial indices if they have been rolled-over already

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group = org.elasticsearch.plugin.ingest
-version = 6.8.1.0-SNAPSHOT
+version = 6.8.1.0

--- a/src/main/java/org/elasticsearch/ingest/openshift/OpenshiftIndexProcessor.java
+++ b/src/main/java/org/elasticsearch/ingest/openshift/OpenshiftIndexProcessor.java
@@ -16,8 +16,6 @@
 
 package org.elasticsearch.ingest.openshift;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.metadata.AliasOrIndex;
@@ -42,7 +40,6 @@ import static org.elasticsearch.ingest.openshift.OpenshiftIndicesUtil.hasDataMod
  * Every instance of this plugin keeps its own lookup table of latest indices/aliases.
  */
 public final class OpenshiftIndexProcessor extends AbstractProcessor {
-    private static final Logger logger = LogManager.getLogger(OpenshiftIndexProcessor.class);
 
     public static final String TYPE = "openshift-ingestion-processor";
 

--- a/src/main/java/org/elasticsearch/ingest/openshift/OpenshiftIndicesUtil.java
+++ b/src/main/java/org/elasticsearch/ingest/openshift/OpenshiftIndicesUtil.java
@@ -28,21 +28,21 @@ import java.util.stream.Collectors;
 public abstract class OpenshiftIndicesUtil {
 
     /**
-     * Replaces ending "-write" with "-00001".
+     * Does trim() and replaces "-write" suffix with "-00001".
      * @param aliasName assume write-alias
      * @return initial index name
      */
     public static String generateInitialIndexName(final String aliasName) {
-        return aliasName.replaceAll("-write$", "-000001");
+        return aliasName.trim().replaceAll("-write$", "-000001");
     }
 
     /**
-     * Replaces ending "-00001" with "-write".
+     * Does trim() and replaces "-00001" suffix with "-write".
      * @param index assume initialIndex
      * @return write-alias
      */
     public static String generateWriteAliasName(final String index) {
-        return index.replaceAll("-000001$", "-write");
+        return index.trim().replaceAll("-000001$", "-write");
     }
 
     public static boolean isInitialIndex(final String index) {

--- a/src/main/java/org/elasticsearch/ingest/openshift/OpenshiftIndicesUtil.java
+++ b/src/main/java/org/elasticsearch/ingest/openshift/OpenshiftIndicesUtil.java
@@ -74,7 +74,9 @@ public abstract class OpenshiftIndicesUtil {
                             if (!isInitialIndex(imd.getIndex().getName())) return false;
                             if (!hasDataModelPrefix(imd.getIndex().getName())) return false;
                             for (ObjectCursor<AliasMetaData> md: imd.getAliases().values()) {
-                                if (md.value.writeIndex()) {
+                                // Alias metadata can be undefined because the Builder does not require all MetaData to
+                                // be specified. See <org.elasticsearch.cluster.metadata.AliasMetaData.Builder>.
+                                if (md.value.writeIndex() != null && md.value.writeIndex()) {
                                     return false;
                                 }
                             }

--- a/src/main/java/org/elasticsearch/ingest/openshift/OpenshiftIngestPlugin.java
+++ b/src/main/java/org/elasticsearch/ingest/openshift/OpenshiftIngestPlugin.java
@@ -103,7 +103,6 @@ public class OpenshiftIngestPlugin extends Plugin implements IngestPlugin, Clust
             synchronized (this) {
                 if (eventState.version() > clusterStateVersion) {
                     latestAliasAndIndicesLookup = eventState.metaData().getAliasAndIndexLookup();
-                    logger.trace("New version of metadata: {} > {}", eventState.version(), clusterStateVersion);
                     clusterStateVersion = eventState.version();
                 }
             }
@@ -118,7 +117,6 @@ public class OpenshiftIngestPlugin extends Plugin implements IngestPlugin, Clust
              */
             if (event.localNodeMaster()) {
 
-                logger.trace("Master node is handling new metadata");
                 List<String> indices = getInitialIndicesWithoutWriteAlias(latestAliasAndIndicesLookup);
                 if (!indices.isEmpty()) {
                     IndicesAliasesRequestBuilder iarb = client.admin().indices().prepareAliases();
@@ -133,7 +131,7 @@ public class OpenshiftIngestPlugin extends Plugin implements IngestPlugin, Clust
                                     .index(index)
                                     .alias(writeAlias)
                                     .writeIndex(true));
-                            logger.trace("Prepare new index alias {} request for index {}", writeAlias, index);
+                            logger.trace("Prepared write index alias {} request for index {}", writeAlias, index);
                         }
                     }
 
@@ -153,7 +151,6 @@ public class OpenshiftIngestPlugin extends Plugin implements IngestPlugin, Clust
                                 logger.warn("Error occurred when adding write aliases for the following indices: {}. {}", indices, e);
                             }
                         });
-                        logger.trace("Request to create new index aliases created");
                     }
                 }
             }

--- a/src/test/java/org/elasticsearch/ingest/openshift/OpenshiftIndicesUtilTests.java
+++ b/src/test/java/org/elasticsearch/ingest/openshift/OpenshiftIndicesUtilTests.java
@@ -39,12 +39,16 @@ public class OpenshiftIndicesUtilTests extends ESTestCase {
         assertEquals("app-000001", generateInitialIndexName("app-write"));
         assertEquals("alias-write-000001", generateInitialIndexName("alias-write-write"));
         assertEquals("-000001", generateInitialIndexName("-write"));
+
+        assertEquals("app-000001", generateInitialIndexName("   app-write  "));
     }
 
     public void testGenerateWriteAliasName() {
         assertEquals("app-write", generateWriteAliasName("app-000001"));
         assertEquals("foo-write-write", generateWriteAliasName("foo-write-000001"));
         assertEquals("-write", generateWriteAliasName("-000001"));
+
+        assertEquals("app-write", generateWriteAliasName("   app-000001  "));
     }
 
     public void testDataModelPrefix() {

--- a/src/test/resources/rest-api-spec/test/ingest/20_define_pipeline.yml
+++ b/src/test/resources/rest-api-spec/test/ingest/20_define_pipeline.yml
@@ -6,6 +6,7 @@
       cluster.put_settings:
         body:
           transient:
+            action.auto_create_index: "-*-write,+*"
             logger:
               org.elasticsearch.ingest.openshift: "TRACE"
               org.elasticsearch.action: "DEBUG"

--- a/src/test/resources/rest-api-spec/test/ingest/20_define_pipeline.yml
+++ b/src/test/resources/rest-api-spec/test/ingest/20_define_pipeline.yml
@@ -6,7 +6,9 @@
       cluster.put_settings:
         body:
           transient:
-            logger.org.elasticsearch.ingest.openshift: "TRACE"
+            logger:
+              org.elasticsearch.ingest.openshift: "TRACE"
+              org.elasticsearch.action: "DEBUG"
         flat_settings: true
   - match: { acknowledged: true }
 

--- a/src/test/resources/rest-api-spec/test/ingest/30_rollover.yml
+++ b/src/test/resources/rest-api-spec/test/ingest/30_rollover.yml
@@ -6,6 +6,7 @@
       cluster.put_settings:
         body:
           transient:
+            action.auto_create_index: "-*-write,+*"
             logger:
               org.elasticsearch.ingest.openshift: "TRACE"
               org.elasticsearch.action: "DEBUG"

--- a/src/test/resources/rest-api-spec/test/ingest/30_rollover.yml
+++ b/src/test/resources/rest-api-spec/test/ingest/30_rollover.yml
@@ -6,7 +6,9 @@
       cluster.put_settings:
         body:
           transient:
-            logger.org.elasticsearch.ingest.openshift: "TRACE"
+            logger:
+              org.elasticsearch.ingest.openshift: "TRACE"
+              org.elasticsearch.action: "DEBUG"
         flat_settings: true
   - match: { acknowledged: true }
 


### PR DESCRIPTION
We are getting list of initial indices without write alias to operate
on later (i.e. we create write alias for them).
There can be, however, a valid case when initial index had the write
alias but after the rollover a new index has been created and the write
alias was pointed at this new index.

The situation looks like this:

```
app-foo-000001
app-foo-000002 <- app-foo-write
```

In this case we need to skip the initial index without write alias.
It is valid case and we shall not try to create write alias for it.
This was causing unnecessary exception being thrown out.

We also improve ITs by introducing the same setting that is found
in production:
```
action.auto_create_index: "-*-write,+*"
```
this is to prove that once the initial index (`*-000001`) is created
the consequent creation of index alias matching the pattern (`*-write`)
is not blocked.

Last, but not least, we fix NPW when checking alias metadata `writeAlias`.